### PR TITLE
Task ii

### DIFF
--- a/src/main/java/streamapi/Main.java
+++ b/src/main/java/streamapi/Main.java
@@ -15,6 +15,14 @@ public class Main {
         // Task I: Students
 
         // Task II: Set of ECTS of all IFM students
+        System.out.println(
+                ifmCps(
+                        List.of(
+                                new Student("A", 35, Enrollment.IFM),
+                                new Student("B", 35, Enrollment.IFM),
+                                new Student("C", 60, Enrollment.ELT),
+                                new Student("D", 45, Enrollment.ARCH),
+                                new Student("E", 80, Enrollment.IFM))));
 
         // Task III: Random
 
@@ -45,7 +53,16 @@ public class Main {
      */
     public static Set<Integer> ifmCps(List<Student> studentList) {
         // TODO
-        throw new UnsupportedOperationException();
+        Set<Integer> result = new HashSet<>();
+        Integer i = 0;
+        for (Student v : studentList) {
+            if (v.isIFM()) {
+                i = v.cps();
+                result.add(i);
+            }
+        }
+
+        return result;
     }
 
     /**


### PR DESCRIPTION
selbe Funktionalität unter Nutzung der Java-Stream-API, ebenso verwendung von Methodenreferenz die doppelte Ausgaben verhindert.